### PR TITLE
Gamemode Role Assignment

### DIFF
--- a/code/datums/gamemodes/nations.dm
+++ b/code/datums/gamemodes/nations.dm
@@ -1,12 +1,3 @@
-/// Initially populated with the default nation types.
-var/list/roundstart_nation_types = list(
-	/datum/nation/engineering,
-	/datum/nation/medical,
-	/datum/nation/research,
-	/datum/nation/service,
-	/datum/nation/supply,
-)
-
 /datum/game_mode/nations
 	name = "Nations"
 	config_tag = "nations"
@@ -14,7 +5,14 @@ var/list/roundstart_nation_types = list(
 	do_antag_random_spawns = 0
 	latejoin_antag_compatible = 0
 
+	/// A list of nation datums to assign minds to.
 	var/list/datum/nation/nations = list()
+	/// An associative list of job datum types and the leader antagonist role that they should be assigned.
+	var/alist/leader_jobs_to_roles = alist()
+	/// An associative list of job datum types and the antagonist role that they should be assigned.
+	var/alist/jobs_to_roles = alist()
+	/// An associative list of job categories and the antagonist role that they should be assigned.
+	var/alist/cats_to_roles = alist()
 
 /datum/game_mode/nations/announce()
 	boutput(world, "<B>The current game mode is - Nations!</B>")
@@ -26,99 +24,71 @@ var/list/roundstart_nation_types = list(
 		logTheThing(LOG_DEBUG, src, "Nations gamemode is being started without the Nations map! Careful!")
 		message_admins("Nations gamemode is being started without the Nations map! Careful!")
 
+	for (var/nation_type as anything in global.concrete_typesof(/datum/nation))
+		var/datum/nation/nation = global.get_singleton(nation_type)
+		src.nations += nation
+		src.leader_jobs_to_roles += nation.leader_jobs
+
+		for (var/job_type as anything in (nation.leader_jobs + nation.citizen_jobs))
+			src.jobs_to_roles[job_type] = nation.citizen_role
+
+		for (var/job_category as anything in nation.citizen_job_categories)
+			src.cats_to_roles[job_category] = nation.citizen_role
+
 /datum/game_mode/nations/post_setup()
 	var/list/datum/mind/client_minds = list()
-	for (var/client/client)
-		if (!isliving(client.mob))
+	for (var/client/C as anything in global.clients)
+		if (!isliving(C.mob) || !ismind(C.mob.mind))
 			continue
-		client_minds += client?.mob.mind
 
-	for (var/nation_type in roundstart_nation_types)
-		src.nations += global.get_singleton(nation_type)
+		client_minds += C.mob.mind
 
-	client_minds = src.populate_nations(client_minds)
+	shuffle_list(client_minds)
 
-	var/list/nation_populations = list()
-	for (var/datum/nation/nation in src.nations)
-		if (!length(nation.citizens))
-			continue
-		if (!nation.leader)
-			nation.add_leader(pick(nation.citizens))
-		nation_populations += "[nation.name] ([length(nation.citizens)])"
-	if (length(nation_populations))
-		logTheThing(LOG_GAMEMODE, src, "set up the following nations: [english_list(nation_populations)]")
-		message_admins("Nations: Set up the following nations: [english_list(nation_populations)]")
-
-	if (length(client_minds))
-		var/list/remaining_client_minds = list()
-		for (var/datum/mind/candidate in client_minds)
-			remaining_client_minds += "[key_name(candidate)]"
-		logTheThing(LOG_GAMEMODE, src, "has rendered [length(client_minds)] players ([english_list(remaining_client_minds)]) stateless!")
-		message_admins("Nations: rendered [length(client_minds)] players stateless!")
+	for (var/datum/mind/mind as anything in client_minds)
+		src.assign_role(mind, global.find_job_in_controller_by_string(mind.assigned_role))
 
 /datum/game_mode/nations/send_intercept(badguy_list)
 	return
 
-/datum/game_mode/nations/proc/populate_nations(list/datum/mind/client_minds)
-	logTheThing(LOG_GAMEMODE, src, "attempting to populate each nation.")
-	message_admins("Nations: Attempting to populate each nation.")
-	if (!length(src.nations))
-		logTheThing(LOG_GAMEMODE, src, "was unable to populate the nations as they don't seem to exist! Aborting!")
-		message_admins("Nations: Unable to populate the nations as they don't seem to exist! Aborting!")
+/datum/game_mode/nations/proc/assign_role(datum/mind/mind, datum/job/job)
+	if (!istype(job))
 		return
-	if (!length(client_minds))
-		logTheThing(LOG_GAMEMODE, src, "was unable to populate the nations as no valid candidates were found!")
-		message_admins("Nations: Unable to populate the nations as no valid candidates were found!")
-		return
-	shuffle_list(client_minds)
-	for (var/datum/mind/candidate_mind in client_minds)
-		if (!src.assign_to_a_nation(candidate_mind))
-			continue
-		if (!iscarbon(candidate_mind.current))
-			continue
-		client_minds -= candidate_mind
-	return client_minds
 
-/datum/game_mode/nations/proc/assign_to_a_nation(datum/mind/candidate_mind, candidate_job)
-	. = TRUE
-	if (!ismind(candidate_mind))
-		return FALSE
-	var/datum/job/mind_job
-	if (istype(candidate_job, /datum/job))
-		mind_job = candidate_job
-	else
-		mind_job = find_job_in_controller_by_string(candidate_mind.assigned_role)
-	for (var/datum/nation/nation in src.nations)
-		if ((mind_job.type in nation.leader_jobs) && !nation.leader)
-			nation.add_leader(candidate_mind.current.mind)
-			return
-		if ((mind_job.type) in nation.citizen_jobs)
-			nation.add_citizen(candidate_mind.current.mind)
-			return
-		if (mind_job.job_category in nation.citizen_job_categories)
-			nation.add_citizen(candidate_mind.current.mind)
-			return
-	. = FALSE
+	var/leader_role = null
+	var/role = null
+	var/datum/job/job_type = job.type
+	while (job_type != /datum/job)
+		leader_role ||= src.leader_jobs_to_roles[job_type]
+		role ||= src.jobs_to_roles[job_type]
+		job_type = job_type::parent_type
 
-/datum/game_mode/nations/proc/handle_latejoin(datum/mind/new_mind, datum/job/new_mind_job)
+	role ||= src.cats_to_roles[job.job_category]
+
+	// If a leader role is found, assign that role to the mind and remove it from the list, so that it isn't assigned twice.
+	if (leader_role)
+		role = leader_role
+
+		for (var/datum/job/leader_job_type as anything in src.leader_jobs_to_roles)
+			if (src.leader_jobs_to_roles[leader_job_type] == leader_role)
+				src.leader_jobs_to_roles -= leader_job_type
+
+	if (role)
+		mind.add_antagonist(role, respect_mutual_exclusives = FALSE)
+		return TRUE
+
+	return FALSE
+
+/datum/game_mode/nations/proc/handle_latejoin(datum/mind/mind, datum/job/job)
 	var/turf/spawn_turf = pick_landmark(LANDMARK_LATEJOIN, locate(1, 1, 1))
 	var/obj/cryotron/latejoin_cryotron = locate(/obj/cryotron) in spawn_turf
-	if (istype(latejoin_cryotron, /obj/cryotron))
-		latejoin_cryotron.add_person_to_queue(new_mind.current, new_mind_job)
+	if (istype(latejoin_cryotron))
+		latejoin_cryotron.add_person_to_queue(mind.current, job)
 	else
-		new_mind.current?.set_loc(spawn_turf)
-	if (src.assign_to_a_nation(new_mind, new_mind_job))
-		return
-	logTheThing(LOG_GAMEMODE, new_mind.current, "attempted to latejoin and was not assigned to the UN or any nation!")
-	message_admins("Nations: [key_name(new_mind)] attempted to latejoin and was not assigned to the UN or any nation!")
+		mind.current?.set_loc(spawn_turf)
 
-/datum/game_mode/nations/proc/get_nation(mob/living/carbon/target)
-	RETURN_TYPE(/datum/nation)
-
-	. = null
-	if (!iscarbon(target))
+	if (src.assign_role(mind, job))
 		return
-	for (var/datum/nation/nation in src.nations)
-		if (!(target.mind in nation.citizens))
-			continue
-		return nation
+
+	logTheThing(LOG_GAMEMODE, mind.current, "attempted to latejoin and was not assigned to the UN or any nation!")
+	message_admins("Nations: [key_name(mind)] attempted to latejoin and was not assigned to the UN or any nation!")

--- a/code/modules/antagonists/nations/nation.dm
+++ b/code/modules/antagonists/nations/nation.dm
@@ -1,3 +1,4 @@
+ABSTRACT_TYPE(/datum/nation)
 /datum/nation
 	var/name = ""
 	/// For displaying the short-form on Passports.
@@ -8,34 +9,52 @@
 	/// For custom-generated passports as well as the UI.
 	var/passport_color = "#1a378d"
 
-	var/citizen_role = null
+	/// The leader jobs of this nation, associated with the antagonist role that they are assigned.
+	var/alist/leader_jobs = alist()
 
-	/// List of jobs which provide the highest priority candidates for the nation's leader at roundstart.
-	var/list/leader_jobs = list()
+	/// The antagonist role that all citizens of the nation are assigned.
+	var/citizen_role = null
 	/// List of jobs which are assigned regular citizenship to this nation at roundstart. Checked FIRST. As /datum/job types.
 	var/list/citizen_jobs = list()
 	/// List of jobs categories which are assigned regular citizenship to this nation at roundstart. Checked SECOND. See `_std/defines/job.dm`.
 	var/list/citizen_job_categories = list()
 
-	var/datum/mind/leader = null
+	var/alist/leaders = alist()
 	var/list/datum/mind/citizens = list()
 
-/datum/nation/proc/add_leader(datum/mind/new_leader)
-	if (src.leader == new_leader)
-		return
-	if (src.leader)
-		var/datum/mind/old_leader = src.leader
-		logTheThing(LOG_GAMEMODE, src, "removed [key_name(old_leader)] as leader of [src.name]!")
-	src.leader = new_leader
-	src.add_citizen(new_leader)
-	logTheThing(LOG_GAMEMODE, src, "installed [key_name(new_leader)] as leader of [src.name]!")
+/datum/nation/New()
+	. = ..()
 
-/datum/nation/proc/remove_leader(datum/mind/leader)
-	src.remove_citizen(leader)
-	if (src.leader != leader)
+	for (var/job as anything in src.leader_jobs)
+		src.leaders += src.leader_jobs[job]
+
+/datum/nation/proc/add_leader(datum/mind/new_leader, role_id)
+	var/datum/mind/current_leader = src.leaders[role_id]
+	if (current_leader == new_leader)
 		return
-	src.leader = null
-	logTheThing(LOG_GAMEMODE, src, "removed [key_name(leader)] as leader of [src.name]!")
+
+	if (current_leader)
+		current_leader.add_antagonist(src.citizen_role, respect_mutual_exclusives = FALSE)
+		logTheThing(LOG_GAMEMODE, src, "removed [key_name(current_leader)] as leader ([role_id]) of [src.name]!")
+
+	src.leaders[role_id] = new_leader
+	src.add_citizen(new_leader)
+	logTheThing(LOG_GAMEMODE, src, "installed [key_name(new_leader)] as leader ([role_id]) of [src.name]!")
+
+/datum/nation/proc/remove_leader(datum/mind/leader, role_id)
+	src.remove_citizen(leader)
+	if (src.leaders[role_id] != leader)
+		return
+
+	src.leaders[role_id] = null
+	logTheThing(LOG_GAMEMODE, src, "removed [key_name(leader)] as leader ([role_id]) of [src.name]!")
+
+/datum/nation/proc/is_leader(datum/mind/mind)
+	for (var/role_id as anything in src.leaders)
+		if (src.leaders[role_id] == mind)
+			return TRUE
+
+	return FALSE
 
 /datum/nation/proc/add_citizen(datum/mind/new_citizen)
 	if (new_citizen in src.citizens)
@@ -53,12 +72,14 @@
 	name = "United Nations"
 	passport_type = /obj/item/passport/un
 	passport_color = "#24639a"
+	leader_jobs = alist(
+		/datum/job/command/captain = ROLE_UN_SECGEN,
+		/datum/job/command/head_of_security = ROLE_UN_UNDSEC,
+	)
 	citizen_role = ROLE_UN
-	leader_jobs = list(/datum/job/command/captain)
 	citizen_jobs = list(
 		/datum/job/civilian/AI,
 		/datum/job/civilian/cyborg,
-		/datum/job/command/head_of_security,
 	)
 	citizen_job_categories = list(JOB_SECURITY)
 
@@ -66,32 +87,32 @@
 	name = "Engistan"
 	passport_type = /obj/item/passport/engineering
 	passport_color = "#d37610"
+	leader_jobs = alist(/datum/job/command/chief_engineer = ROLE_NATION_ENG_LEADER)
 	citizen_role = ROLE_NATION_ENG
-	leader_jobs = list(/datum/job/command/chief_engineer)
 	citizen_job_categories = list(JOB_ENGINEERING)
 
 /datum/nation/medical
 	name = "Asclepius"
 	passport_type = /obj/item/passport/medical
 	passport_color = "#c9294e"
+	leader_jobs = alist(/datum/job/command/medical_director = ROLE_NATION_MED_LEADER)
 	citizen_role = ROLE_NATION_MED
-	leader_jobs = list(/datum/job/command/medical_director)
 	citizen_job_categories = list(JOB_MEDICAL)
 
 /datum/nation/research
 	name = "Erudite"
 	passport_type = /obj/item/passport/research
 	passport_color = "#5a1d8a"
+	leader_jobs = alist(/datum/job/command/research_director = ROLE_NATION_SCI_LEADER)
 	citizen_role = ROLE_NATION_SCI
-	leader_jobs = list(/datum/job/command/research_director)
 	citizen_job_categories = list(JOB_RESEARCH)
 
 /datum/nation/service
 	name = "\the Grey Horde"
 	passport_type = /obj/item/passport/service
 	passport_color = "#167935"
+	leader_jobs = alist(/datum/job/command/head_of_personnel = ROLE_NATION_SER_LEADER)
 	citizen_role = ROLE_NATION_SER
-	leader_jobs = list(/datum/job/command/head_of_personnel)
 	citizen_job_categories = list(
 		JOB_CIVILIAN,
 		JOB_CLOWN,
@@ -102,6 +123,7 @@
 	short_name = "Cargonia"
 	passport_type = /obj/item/passport/supply
 	passport_color = "#4a301b"
+	leader_jobs = alist(/datum/job/engineering/quartermaster = ROLE_NATION_SUP_LEADER)
 	citizen_role = ROLE_NATION_SUP
 	citizen_jobs = list(
 		/datum/job/engineering/miner,

--- a/code/modules/antagonists/nations/passports/_passport_parent.dm
+++ b/code/modules/antagonists/nations/passports/_passport_parent.dm
@@ -6,6 +6,8 @@
 	qdel(src.passport)
 	src.passport = passport
 
+
+ABSTRACT_TYPE(/obj/item/passport)
 /obj/item/passport
 	name = "passport"
 	desc = "An identity document confirming its owner's citizenship or lack thereof."
@@ -33,30 +35,34 @@
 /obj/item/passport/New(newLoc, datum/mind/owner_to_assign, give_antag_role = TRUE)
 	. = ..()
 
+	if (!ispath(src.nation_type))
+		qdel(src)
+		CRASH("Cannot instantiate a nationless passport.")
+
+	if (!istype(owner_to_assign))
+		qdel(src)
+		CRASH("Cannot instantiate passport without an owner.")
+
+	src.nation = global.get_singleton(src.nation_type)
+
 	if (src.minimap_marker)
 		src.AddComponent(/datum/component/minimap_marker/minimap, (MAP_NATIONS_UN | src.minimap_type), src.minimap_marker, list_on_ui = FALSE)
 
-	if (src.nation_type)
-		src.nation = global.get_singleton(src.nation_type)
-
-	if (!src.custom_name && src.nation)
+	if (src.custom_name)
+		src.base_name = src.name
+	else
 		src.base_name = "passport ([src.nation.name])"
-
-	if (!ismind(owner_to_assign))
-		return
 
 	src.owner = owner_to_assign
 	src.owner.set_passport(src)
+	src.set_owner_name()
+	src.owner_icon = src.owner.current.build_flat_icon(SOUTH)
 
 	if (give_antag_role)
 		src.owner.add_antagonist(src.nation.citizen_role, respect_mutual_exclusives = FALSE)
 
-	src.set_owner_name()
-
-	src.owner_icon = src.owner.current.build_flat_icon(SOUTH)
-
 /obj/item/passport/disposing()
-	if (src.owner && (src.owner.passport == src))
+	if (src.owner.passport == src)
 		src.owner.set_passport(null)
 
 	. = ..()
@@ -83,11 +89,11 @@
 
 /obj/item/passport/ui_data(mob/user)
 	. = list(
-		"isLeader" = src.nation?.leader == user.mind ? TRUE : FALSE,
-		"isOwner" = src.owner == user.mind ? TRUE : FALSE,
-		"nationColor" = src.nation?.passport_color,
-		"nationName" = src.nation?.name,
-		"nationShortName" = src.nation?.short_name,
+		"isLeader" = src.nation.is_leader(user.mind),
+		"isOwner" = (src.owner == user.mind),
+		"nationColor" = src.nation.passport_color,
+		"nationName" = src.nation.name,
+		"nationShortName" = src.nation.short_name,
 		"ownerRoleType" = src.get_owner_role_type(),
 	)
 
@@ -113,8 +119,6 @@
 	actions.start(new /datum/action/show_item(user, src, "passport", 5, 3), user)
 
 /obj/item/passport/proc/set_owner_name()
-	if (!src.owner)
-		return
 	src.owner_name = src.owner.current?.real_name
 	src.name = "[src.owner_name]’s [src.base_name]"
 

--- a/code/modules/antagonists/nations/passports/passport_creation.dm
+++ b/code/modules/antagonists/nations/passports/passport_creation.dm
@@ -44,7 +44,7 @@
 		return
 
 	var/datum/nation/nation = global.get_singleton(nation_type)
-	if (user.mind != nation.leader)
+	if (!nation.is_leader(user.mind))
 		boutput(user, SPAN_ALERT("You aren't the leader of that nation!"))
 		return
 
@@ -52,7 +52,7 @@
 		boutput(user, SPAN_ALERT("Passport VOID: This paper was stamped too long ago by the applicant!"))
 		return
 
-	if ((user.mind != src.passport_recipient) && (src.passport_recipient.passport?.nation?.leader == src.passport_recipient))
+	if ((user.mind != src.passport_recipient) && src.passport_recipient.passport?.nation.is_leader(src.passport_recipient))
 		boutput(user, SPAN_ALERT("You can't grant citizenship to rival leaders!"))
 		return
 

--- a/code/modules/antagonists/nations/roles/_nation_role_parent.dm
+++ b/code/modules/antagonists/nations/roles/_nation_role_parent.dm
@@ -57,8 +57,8 @@ ABSTRACT_TYPE(/datum/antagonist/nation/leader)
 
 /datum/antagonist/nation/leader/give_equipment()
 	. = ..()
-	src.passport.nation.add_leader(src.owner)
+	src.passport.nation.add_leader(src.owner, src.id)
 
 /datum/antagonist/nation/leader/remove_equipment()
-	src.passport.nation.remove_leader(src.owner)
+	src.passport.nation.remove_leader(src.owner, src.id)
 	. = ..()


### PR DESCRIPTION
## About The PR:
The Nations gamemode now correctly assigns antagonist roles. Nations now support multiple leaders. Replacing a leader now automatically removes the former leader's antagonist role and makes them a citizen.

The Nations gamemode supports assigning a leader role to a citizen job if no specific leader job is defined (see QM); nevertheless I would recommend creating Head of Supply and Ringmaster jobs for use with the nepotism system.

Antagonist roles assigned through the nepotism system are currently overwritten by the gamemode.
